### PR TITLE
Clean up Axios calls & remove baseURL

### DIFF
--- a/src/components/common/TeacherForm.js
+++ b/src/components/common/TeacherForm.js
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
 import { Form, Input, Button, message } from 'antd';
-import axios from 'axios';
+import { axiosWithAuth } from '../../utils/axiosWithAuth';
 import { useHistory } from 'react-router-dom';
-
 
 // This reusable component is strictly for the "Teacher" input feilds
 
@@ -30,8 +29,8 @@ function TeacherForm() {
   };
 
   const addTeacher = newTeacher => {
-    axios
-      .post('https://vbb-mock-api.herokuapp.com/teacher', newTeacher)
+    axiosWithAuth()
+      .post('/teacher', newTeacher)
       .then(response => {
         history.push('/');
       })
@@ -46,7 +45,6 @@ function TeacherForm() {
       style={{ display: 'flex', justifyContent: 'center', paddingTop: '2rem' }}
     >
       <Form form={form} onFinish={onFinish} name="register" scrollToFirstError>
-
         <h1>Teacher Registration Form</h1>
 
         <Form.Item

--- a/src/components/pages/Headmaster/HeadmasterProfile/ProfileForm.js
+++ b/src/components/pages/Headmaster/HeadmasterProfile/ProfileForm.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { useParams, useHistory, Link } from 'react-router-dom';
-import axios from 'axios';
+import { axiosWithAuth } from '../../../../utils/axiosWithAuth';
 
 import { Form, Input, DatePicker, Space, Radio } from 'antd';
 import moment from 'moment';
@@ -47,7 +47,7 @@ const ProfileForm = props => {
   const [form] = Form.useForm();
 
   useEffect(() => {
-    axios // ! This should later become available through axiosWithAuth() only once we figure out the Auth with Stakeholder's backend
+    axiosWithAuth()
       .get(`${baseURL}/headmaster/1`)
       .then(res => {
         form.setFieldsValue(res.data);

--- a/src/components/pages/Headmaster/HeadmasterProfile/ProfileForm.js
+++ b/src/components/pages/Headmaster/HeadmasterProfile/ProfileForm.js
@@ -9,7 +9,7 @@ import { editHeadmasterProfile } from '../../../../state/actions';
 import { debugLog } from '../../../../utils/debugMode';
 import { Button } from 'antd';
 
-const baseURL = 'https://cors-anywhere.herokuapp.com/http://54.158.134.245/api';
+// const baseURL = 'https://cors-anywhere.herokuapp.com/http://54.158.134.245/api';
 
 const initialState = {
   first_name: '',
@@ -48,7 +48,7 @@ const ProfileForm = props => {
 
   useEffect(() => {
     axiosWithAuth()
-      .get(`${baseURL}/headmaster/1`)
+      .get(`/headmaster/1`)
       .then(res => {
         form.setFieldsValue(res.data);
         setFormData(res.data);

--- a/src/components/pages/School/SchoolForm.js
+++ b/src/components/pages/School/SchoolForm.js
@@ -5,7 +5,7 @@ import { Form, Input, Button } from 'antd';
 import { editSchool } from '../../../state/actions';
 import { axiosWithAuth } from '../../../utils/axiosWithAuth';
 
-const baseURL = 'https://cors-anywhere.herokuapp.com/http://54.158.134.245/api';
+// const baseURL = 'https://cors-anywhere.herokuapp.com/http://54.158.134.245/api';
 
 const initialState = {
   name: '',

--- a/src/components/pages/Student/StudentForm.js
+++ b/src/components/pages/Student/StudentForm.js
@@ -20,8 +20,8 @@ function StudentForm() {
   };
 
   const addStudent = newStudent => {
-    axiosWithAuth(addStudent)
-      .post('https://vbb-mock-api.herokuapp.com/mentee', newStudent)
+    axiosWithAuth()
+      .post('/mentee', newStudent)
       .then(response => {
         history.push('/');
       })

--- a/src/components/pages/Village/VillageForm.js
+++ b/src/components/pages/Village/VillageForm.js
@@ -6,7 +6,7 @@ import { Form, Input } from 'antd';
 import { editVillage } from '../../../state/actions';
 import { Button } from 'antd';
 
-const baseURL = 'https://cors-anywhere.herokuapp.com/http://54.158.134.245/api';
+// const baseURL = 'https://cors-anywhere.herokuapp.com/http://54.158.134.245/api';
 
 //! use real name when full server is developed
 const initialState = {

--- a/src/state/actions/index.js
+++ b/src/state/actions/index.js
@@ -21,9 +21,9 @@ export const checkToken = data => dispatch => {
 // AUTHORIZATION
 // -------------------------
 export const login = data => dispatch => {
-  axios
+  axiosWithAuth()
     // will need to update this to baseURL, there seems to be a link issue with the .env file
-    .post('https://vbb-mock-api.herokuapp.com/auth/login', data)
+    .post('/auth/login', data)
     .then(res => {
       // console.log('LOGIN ACTION SUCCESS --> token', res.data);
       window.localStorage.setItem('token', res.data.access_token);
@@ -246,7 +246,7 @@ export const editSchool = (id, data) => dispatch => {
 export const fetchMentors = () => dispatch => {
   dispatch({ type: actionTypes.FETCH_MENTOR_START });
   axiosWithAuth()
-    .get(`https://vbb-mock-api.herokuapp.com/mentor`)
+    .get(`/mentor`)
     .then(res => {
       dispatch({ type: actionTypes.FETCH_MENTOR_SUCCESS, payload: res.data });
     })

--- a/src/state/actions/index.js
+++ b/src/state/actions/index.js
@@ -3,12 +3,10 @@
 // Actions should be focused to a single purpose.
 // You can have multiple action creators per file if it makes sense to the purpose those action creators are serving.
 // Declare action TYPES at the top of the file
-import axios from 'axios';
 import { axiosWithAuth } from '../../utils/axiosWithAuth';
-import { useHistory } from 'react-router-dom';
 
 import * as actionTypes from './actionTypes';
-const baseURL = process.env.REACT_APP_BASE_URL;
+// const baseURL = process.env.REACT_APP_BASE_URL;
 
 export const checkToken = data => dispatch => {
   dispatch({
@@ -33,11 +31,7 @@ export const login = data => dispatch => {
       });
     })
     .catch(err => {
-      console.log(
-        'LOGIN ACTION FAILURE--> with this data & baseURL:',
-        data,
-        baseURL
-      );
+      console.log('LOGIN ACTION FAILURE--> with this data:', data);
       console.dir(err);
     });
 };

--- a/src/utils/axiosWithAuth.js
+++ b/src/utils/axiosWithAuth.js
@@ -9,6 +9,7 @@ export const axiosWithAuth = () => {
 
   return axios.create({
     baseURL: 'https://vbb-mock-api.herokuapp.com',
+    // baseURL: 'http://localhost:5000',
     headers: {
       Authorization: token,
     },


### PR DESCRIPTION
There were many calls to the backend using the axiosWithAuth hook that are unnecessarily providing the whole URL when the hook already contains a baseURL.

In addition, there were certain calls that SHOULD be using axiosWithAuth, but weren't and were instead using a baseURL const initialized in the beginning of each file.

https://trello.com/c/gZmUHs4u