### PR TITLE
Improving/naming conventions

### DIFF
--- a/src/components/pages/Headmaster/HeadmasterDashboard.js
+++ b/src/components/pages/Headmaster/HeadmasterDashboard.js
@@ -77,9 +77,7 @@ const HeadmasterDashboard = props => {
               <NavLink to="/mentor-list">Mentor List</NavLink>
             </Menu.Item>
             <Menu.Item key="8" icon={<UnorderedListOutlined />}>
-              <NavLink to="/mentor-mentee-matching">
-                Mentor Mentee Matching
-              </NavLink>
+              <NavLink to="/mentor-mentee-matching">Matching Calendar</NavLink>
             </Menu.Item>
             <Menu.Item key="5" icon={<BookOutlined />}>
               <NavLink to="/school-village">School/Village</NavLink>

--- a/src/components/pages/Headmaster/HeadmasterDashboard.js
+++ b/src/components/pages/Headmaster/HeadmasterDashboard.js
@@ -85,7 +85,7 @@ const HeadmasterDashboard = props => {
               <NavLink to="/school-village">School/Village</NavLink>
             </Menu.Item>
             <Menu.Item key="6" icon={<FormOutlined />}>
-              <NavLink to="/student-search">Student Registration</NavLink>
+              <NavLink to="/student-search">Student Search</NavLink>
             </Menu.Item>
             <Menu.Item key="7" icon={<LogoutOutlined />}>
               <Link to="/logout">Logout</Link>

--- a/src/components/pages/Headmaster/MentorMenteeMatching/MatchingCalendar.js
+++ b/src/components/pages/Headmaster/MentorMenteeMatching/MatchingCalendar.js
@@ -17,10 +17,6 @@ const initialState = {
 const MatchingCalendar = props => {
   const { matches, fetchCalendar } = props;
 
-  useEffect(() => {
-    fetchCalendar();
-  }, [fetchCalendar]);
-
   //-----------------------start calendar code - https://ant.design/components/calendar/
   function dateCellRender(value) {
     const listData = getListData(value);
@@ -59,14 +55,14 @@ const MatchingCalendar = props => {
     console.log(calValue);
   };
 
-  const [clicked, setClicked] = useState(false);
-  const [clicked2, setClicked2] = useState(false);
+  const [clickMenteeList, setClickMenteeList] = useState(false);
+  const [clickMentorList, setClickMentorList] = useState(false);
 
-  const handleClick = () => {
-    setClicked(!clicked);
+  const handleClickMenteeList = () => {
+    setClickMenteeList(!clickMenteeList);
   };
-  const handleClick2 = () => {
-    setClicked2(!clicked2);
+  const handleClickMentorList = () => {
+    setClickMentorList(!clickMentorList);
   };
 
   return (
@@ -166,13 +162,17 @@ const MatchingCalendar = props => {
       <div className="miniListContainer">
         <div className="listButton1">
           <h1>Mentor List</h1>
-          <button onClick={handleClick}>{clicked ? 'Hide' : 'Show'}</button>
-          {clicked ? <MiniMentorList /> : null}
+          <button onClick={handleClickMentorList}>
+            {clickMentorList ? 'Hide' : 'Show'}
+          </button>
+          {clickMentorList ? <MiniMentorList /> : null}
         </div>
         <div className="listButton2">
           <h1>Mentee List</h1>
-          <button onClick={handleClick2}>{clicked2 ? 'Hide' : 'Show'}</button>
-          {clicked2 ? <MiniMenteeList /> : null}
+          <button onClick={handleClickMenteeList}>
+            {clickMenteeList ? 'Hide' : 'Show'}
+          </button>
+          {clickMenteeList ? <MiniMenteeList /> : null}
         </div>
       </div>
     </div>

--- a/src/components/pages/Headmaster/MentorMenteeMatching/MatchingCalendar.js
+++ b/src/components/pages/Headmaster/MentorMenteeMatching/MatchingCalendar.js
@@ -16,6 +16,9 @@ const initialState = {
 
 const MatchingCalendar = props => {
   const { matches, fetchCalendar } = props;
+  useEffect(() => {
+    fetchCalendar();
+  }, [fetchCalendar]);
 
   //-----------------------start calendar code - https://ant.design/components/calendar/
   function dateCellRender(value) {


### PR DESCRIPTION
Made some Improvements in naming.

There was a Student Search component in the dashboard but the naming of it said Student Registration.
Changed it to Student Search because that is what is supposed to do.

Changed the name of MatchingCalendar component being displayed in the page,  previously it was Mentor Mentee Matching but it was too long and it wasn't displaying the whole name.
Changed the name to Matching Calendar since that is the component name and also you can see the whole name.

Changed the States and handleClicks naming in Matching Calendar components to make it more understandable.