### PR TITLE
removed console warning (styled component issue)

### DIFF
--- a/src/components/pages/Headmaster/MentorMenteeMatching/MatchCell.js
+++ b/src/components/pages/Headmaster/MentorMenteeMatching/MatchCell.js
@@ -1,37 +1,44 @@
 import React from 'react';
 import styled from 'styled-components';
 
+const Cell = styled.div`
+  width: 95%;
+  margin: 0;
+  padding: 0.2rem;
+  color: green;
+  background-color: ${props =>
+    props.mentee && props.mentor ? '#cfe3bf' : '#f4e6e6'};
+  border-radius: 0.5rem;
+  text-align: center;
+`;
+
+const Option = styled.a`
+  color: white;
+  font-weight: bold;
+  background-color: ${props =>
+    props.mentee && props.mentor ? '#334814' : '#8e2727'};
+  width: 100%;
+  display: block;
+  border-radius: 0.5rem;
+  margin: 0.1rem 0;
+`;
+
+const Header = styled.h4``;
+
 function MatchCell({ match, className }) {
   const { computerId, time, mentee, mentor } = match;
-  const Cell = styled.div`
-    width: 95%;
-    margin: 0;
-    padding: 0.2rem;
-    color: green;
-    background-color: ${mentee && mentor ? '#cfe3bf' : '#f4e6e6'};
-    border-radius: 0.5rem;
-    text-align: center;
-  `;
-
-  const Header = styled.h4``;
-
-  const Option = styled.a`
-    color: white;
-    font-weight: bold;
-    background-color: ${mentee && mentor ? '#334814' : '#8e2727'};
-    width: 100%;
-    display: block;
-    border-radius: 0.5rem;
-    margin: 0.1rem 0;
-  `;
 
   return (
-    <Cell>
+    <Cell mentee={mentee} mentor={mentor}>
       <Header>
         Computer # {computerId} @ {time}
       </Header>
-      <Option>{mentee ? mentee : '(Not Assigned)'}</Option>
-      <Option>{mentor ? mentor : '(Not Assigned)'}</Option>
+      <Option mentee={mentee} mentor={mentor}>
+        {mentee ? mentee : '(Not Assigned)'}
+      </Option>
+      <Option mentee={mentee} mentor={mentor}>
+        {mentor ? mentor : '(Not Assigned)'}
+      </Option>
       {/* onClick -- opens up modal with necessary information */}
     </Cell>
   );


### PR DESCRIPTION
When computing the colors for the MatchCell component, the computing would happen inside the component itself, causing some unnecessary rendering (and therefore extra console logs)

I fixed this issue and now there are only 2 console logs warnings (a cors one, and an antdesign one) which aren't things we can fix right now.