### PR TITLE
Updated defaultSelectedKeys array to point to Home on nav bar.

### DIFF
--- a/src/components/pages/Headmaster/HeadmasterDashboard.js
+++ b/src/components/pages/Headmaster/HeadmasterDashboard.js
@@ -54,7 +54,7 @@ const HeadmasterDashboard = props => {
             //console.log(collapsed, type);
           }}
         >
-          <Menu mode="inline" defaultSelectedKeys={['4']}>
+          <Menu mode="inline" defaultSelectedKeys={['1']}>
             <div
               style={{
                 display: 'flex',


### PR DESCRIPTION
After the headmaster logs in, originally the item selected on the nav bar was "mentor list" instead of "home." I updated this minor, but satisfying change to improve user experience and lessen complications of where the headmaster is at on their dashboard.

<img width="442" alt="Screen Shot 2021-03-11 at 10 06 26 PM" src="https://user-images.githubusercontent.com/58578511/110886097-12713580-82b6-11eb-84f2-1869f506b97a.png">


# Type

 - [ ] This is a bug fix
 - [ ] This is a new feature
 - [x] This refactors a feature
 - [x] This is to improve performance 

## Organization

- [x] Have you linked this pull request to a Trello card?
https://trello.com/c/X59QnMeT
- [x] Have you named the branch in the format of feature/describe_feature_or_change or in the format of bug/describe_bug_this_fixes?
- [x] Did you add screenshots of your code or the application?

## Review

- [ ] Is this a work in progress?
- [x] Is this ready to be reviewed?
- [x] Have you added two reviewers to this pull request and dropped a message in slack?
